### PR TITLE
feat: add XDC network support for savings widget

### DIFF
--- a/packages/savings-sdk/src/constants.ts
+++ b/packages/savings-sdk/src/constants.ts
@@ -1,0 +1,98 @@
+import { celo, xdc, type Chain } from "viem/chains"
+
+/**
+ * Chains where the GoodDollar Savings (G$ Staking) flow is supported.
+ *
+ * The widget and SDK validate that both the public and wallet clients are
+ * connected to one of these chains. Anything else is treated as a "wrong
+ * network" error so callers can prompt the user to switch.
+ */
+export enum SupportedChainId {
+  CELO = 42220,
+  XDC = 50,
+}
+
+export const SUPPORTED_CHAIN_IDS: SupportedChainId[] = [
+  SupportedChainId.CELO,
+  SupportedChainId.XDC,
+]
+
+export const isSupportedChainId = (
+  chainId: number | undefined,
+): chainId is SupportedChainId =>
+  typeof chainId === "number" &&
+  SUPPORTED_CHAIN_IDS.includes(chainId as SupportedChainId)
+
+export interface SavingsContracts {
+  /** GoodDollarStaking proxy used to stake G$ and claim rewards. */
+  staking: `0x${string}`
+  /** G$ ERC-20 (or SuperGoodDollar) token contract. */
+  gdollar: `0x${string}`
+}
+
+export interface SavingsChainConfig {
+  id: SupportedChainId
+  label: string
+  chain: Chain
+  contracts: SavingsContracts
+}
+
+/**
+ * Default contract addresses per supported chain.
+ *
+ * NOTE: the XDC staking contract has not been deployed at the time of writing.
+ * Integrators that want to enable XDC staking before the official deployment
+ * can override this address through the SDK / widget `contracts` option.
+ */
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000" as const
+
+export const DEFAULT_SAVINGS_CHAIN_CONFIG: Record<
+  SupportedChainId,
+  SavingsChainConfig
+> = {
+  [SupportedChainId.CELO]: {
+    id: SupportedChainId.CELO,
+    label: "Celo",
+    chain: celo,
+    contracts: {
+      staking: "0x799a23dA264A157Db6F9c02BE62F82CE8d602A45",
+      gdollar: "0x62B8B11039FcfE5aB0C56E502b1C372A3d2a9c7A",
+    },
+  },
+  [SupportedChainId.XDC]: {
+    id: SupportedChainId.XDC,
+    label: "XDC Network",
+    chain: xdc,
+    contracts: {
+      staking: "0xeecce52295e907d3A7Da92d69EFF9a2B3f04700B",
+      gdollar: "0xEC2136843a983885AebF2feB3931F73A8eBEe50c",
+    },
+  },
+}
+
+export const getSavingsChainConfig = (
+  chainId: number | undefined,
+): SavingsChainConfig | undefined => {
+  if (!isSupportedChainId(chainId)) return undefined
+  return DEFAULT_SAVINGS_CHAIN_CONFIG[chainId]
+}
+
+export const formatSupportedNetworkList = (): string =>
+  SUPPORTED_CHAIN_IDS.map((id) => DEFAULT_SAVINGS_CHAIN_CONFIG[id].label).join(
+    " or ",
+  )
+
+/**
+ * Error thrown when the SDK is initialised with a client connected to a chain
+ * that is not in {@link SUPPORTED_CHAIN_IDS}.
+ */
+export class UnsupportedChainError extends Error {
+  readonly chainId: number | undefined
+  constructor(chainId: number | undefined) {
+    super(
+      `Unsupported chain ${chainId ?? "<unknown>"}. Connect to ${formatSupportedNetworkList()}.`,
+    )
+    this.name = "UnsupportedChainError"
+    this.chainId = chainId
+  }
+}

--- a/packages/savings-sdk/src/index.ts
+++ b/packages/savings-sdk/src/index.ts
@@ -1,3 +1,4 @@
-export * from "./viem-sdk";
-export { useGooddollarSavings } from "./wagmi-sdk";
-export type { GlobalStats, UserStats } from "./viem-sdk";
+export * from "./viem-sdk"
+export * from "./constants"
+export { useGooddollarSavings } from "./wagmi-sdk"
+export type { GlobalStats, UserStats } from "./viem-sdk"

--- a/packages/savings-sdk/src/viem-sdk.ts
+++ b/packages/savings-sdk/src/viem-sdk.ts
@@ -6,6 +6,16 @@ import {
   type SimulateContractParameters,
 } from "viem"
 
+import {
+  DEFAULT_SAVINGS_CHAIN_CONFIG,
+  SavingsContracts,
+  SupportedChainId,
+  UnsupportedChainError,
+  formatSupportedNetworkList,
+  getSavingsChainConfig,
+  isSupportedChainId,
+} from "./constants"
+
 const STAKING_CONTRACT_ABI = parseAbi([
   "function balanceOf(address account) view returns (uint256)",
   "function earned(address account) view returns (uint256)",
@@ -24,22 +34,6 @@ const G$__ABI = parseAbi([
   "function allowance(address owner, address spender) view returns (uint256)",
 ])
 
-const STAKING_CONTRACT_ADDRESS =
-  "0x799a23dA264A157Db6F9c02BE62F82CE8d602A45" as const
-const GDOLLAR_CONTRACT_ADDRESS =
-  "0x62B8B11039FcfE5aB0C56E502b1C372A3d2a9c7A" as const
-
-
-const stakingContract = {
-  address: STAKING_CONTRACT_ADDRESS,
-  abi: STAKING_CONTRACT_ABI,
-} as const
-
-const gdollarContract = {
-  address: GDOLLAR_CONTRACT_ADDRESS,
-  abi: G$__ABI,
-} as const
-
 export interface GlobalStats {
   totalStaked: bigint // in GDollars wei
   annualAPR: number // in percentage
@@ -52,20 +46,37 @@ export interface UserStats {
   userWeeklyRewards: bigint // in GDollars wei
 }
 
+export interface GooddollarSavingsSDKOptions {
+  /**
+   * Override default contract addresses for one or more supported chains.
+   * Useful when integrating against staging deployments or before a chain's
+   * production staking contract has been registered in the defaults.
+   */
+  contracts?: Partial<Record<SupportedChainId, Partial<SavingsContracts>>>
+}
+
 export class GooddollarSavingsSDK {
   private publicClient: PublicClient
   private walletClient: WalletClient | null = null
   private totalStaked: bigint = BigInt(0)
   private cachedRewardRate: bigint = BigInt(0)
+  private readonly chainId: SupportedChainId
+  private readonly contracts: SavingsContracts
 
   constructor(
     publicClient: PublicClient,
     walletClient?: WalletClient,
+    options: GooddollarSavingsSDKOptions = {},
   ) {
     if (!publicClient) throw new Error("Public client is required")
-    if (!(publicClient.chain?.id === 42220)) {
-      throw new Error("Public client must be connected to Celo mainnet")
+
+    const publicChainId = publicClient.chain?.id
+    if (!isSupportedChainId(publicChainId)) {
+      throw new UnsupportedChainError(publicChainId)
     }
+
+    this.chainId = publicChainId
+    this.contracts = this.resolveContracts(this.chainId, options.contracts)
     this.publicClient = publicClient
     this.walletClient = null
     if (walletClient) {
@@ -73,14 +84,31 @@ export class GooddollarSavingsSDK {
     }
   }
 
+  /** Chain id (Celo / XDC) the SDK is currently bound to. */
+  getChainId(): SupportedChainId {
+    return this.chainId
+  }
+
+  /** Resolved contract addresses for the active chain. */
+  getContracts(): SavingsContracts {
+    return this.contracts
+  }
+
   setWalletClient(walletClient: WalletClient) {
-    if (!(walletClient.chain?.id === 42220)) {
-      throw new Error("Wallet client must be connected to Celo mainnet")
+    const walletChainId = walletClient.chain?.id
+    if (!isSupportedChainId(walletChainId)) {
+      throw new UnsupportedChainError(walletChainId)
+    }
+    if (walletChainId !== this.chainId) {
+      throw new Error(
+        `Wallet client chain ${walletChainId} does not match public client chain ${this.chainId}. Connect to ${formatSupportedNetworkList()}.`,
+      )
     }
     this.walletClient = walletClient
   }
 
   async getGlobalStats(): Promise<GlobalStats> {
+    const stakingContract = this.stakingContract()
     const [totalSupply, periodFinish, effectiveRewardRate] = await Promise.all([
       this.publicClient.readContract({
         ...stakingContract,
@@ -117,6 +145,8 @@ export class GooddollarSavingsSDK {
 
   async getUserStats(): Promise<UserStats> {
     const account = await this.getAccount()
+    const stakingContract = this.stakingContract()
+    const gdollarContract = this.gdollarContract()
 
     const [balance, staked, earned] = await Promise.all([
       this.publicClient.readContract({
@@ -156,6 +186,7 @@ export class GooddollarSavingsSDK {
     if (amount <= BigInt(0)) throw new Error("Amount must be greater than zero")
 
     const account = await this.getAccount()
+    const gdollarContract = this.gdollarContract()
 
     const balance = await this.publicClient.readContract({
       ...gdollarContract,
@@ -171,7 +202,7 @@ export class GooddollarSavingsSDK {
 
     return this.submitAndWait(
       {
-        ...stakingContract,
+        ...this.stakingContract(),
         functionName: "stake",
         args: [amount],
       },
@@ -184,7 +215,7 @@ export class GooddollarSavingsSDK {
 
     return this.submitAndWait(
       {
-        ...stakingContract,
+        ...this.stakingContract(),
         functionName: "withdraw",
         args: [amount],
       },
@@ -195,7 +226,7 @@ export class GooddollarSavingsSDK {
   async claimReward(onHash?: (hash: `0x${string}`) => void) {
     return this.submitAndWait(
       {
-        ...stakingContract,
+        ...this.stakingContract(),
         functionName: "getReward",
         args: [],
       },
@@ -243,10 +274,11 @@ export class GooddollarSavingsSDK {
     onHash?: (hash: `0x${string}`) => void,
   ) {
     const account = await this.getAccount()
+    const gdollarContract = this.gdollarContract()
     const allowance = await this.publicClient.readContract({
       ...gdollarContract,
       functionName: "allowance",
-      args: [account, STAKING_CONTRACT_ADDRESS],
+      args: [account, this.contracts.staking],
     })
 
     if (allowance < amount) {
@@ -254,10 +286,38 @@ export class GooddollarSavingsSDK {
         {
           ...gdollarContract,
           functionName: "approve",
-          args: [STAKING_CONTRACT_ADDRESS, amount],
+          args: [this.contracts.staking, amount],
         },
         onHash,
       )
+    }
+  }
+
+  private stakingContract() {
+    return {
+      address: this.contracts.staking,
+      abi: STAKING_CONTRACT_ABI,
+    } as const
+  }
+
+  private gdollarContract() {
+    return {
+      address: this.contracts.gdollar,
+      abi: G$__ABI,
+    } as const
+  }
+
+  private resolveContracts(
+    chainId: SupportedChainId,
+    overrides: GooddollarSavingsSDKOptions["contracts"],
+  ): SavingsContracts {
+    const defaults =
+      getSavingsChainConfig(chainId)?.contracts ??
+      DEFAULT_SAVINGS_CHAIN_CONFIG[chainId].contracts
+    const override = overrides?.[chainId]
+    return {
+      staking: override?.staking ?? defaults.staking,
+      gdollar: override?.gdollar ?? defaults.gdollar,
     }
   }
 

--- a/packages/savings-sdk/src/wagmi-sdk.ts
+++ b/packages/savings-sdk/src/wagmi-sdk.ts
@@ -1,24 +1,65 @@
-import { useState, useEffect } from "react"
-import { usePublicClient, useWalletClient } from "wagmi";
+import { useEffect, useMemo, useState } from "react"
+import { useChainId, usePublicClient, useWalletClient } from "wagmi"
 import { PublicClient } from "viem"
-import { GooddollarSavingsSDK } from "./viem-sdk";
 
-export function useGooddollarSavings() {
-  const publicClient = usePublicClient() as PublicClient
-  const { data: walletClient } = useWalletClient();
+import { GooddollarSavingsSDK } from "./viem-sdk"
+import {
+  GooddollarSavingsSDKOptions,
+} from "./viem-sdk"
+import {
+  SUPPORTED_CHAIN_IDS,
+  SupportedChainId,
+  formatSupportedNetworkList,
+  isSupportedChainId,
+} from "./constants"
+
+export interface UseGooddollarSavingsResult {
+  sdk: GooddollarSavingsSDK | null
+  loading: boolean
+  error: string | null
+  /** True when wallet is connected to a chain other than Celo / XDC. */
+  isWrongNetwork: boolean
+  /** Active chain id from wagmi (may be unsupported). */
+  chainId: number | undefined
+  /** Chains the savings flow accepts. */
+  supportedChainIds: readonly SupportedChainId[]
+}
+
+export function useGooddollarSavings(
+  options: GooddollarSavingsSDKOptions = {},
+): UseGooddollarSavingsResult {
+  const chainId = useChainId()
+  const publicClient = usePublicClient({ chainId }) as PublicClient | undefined
+  const { data: walletClient } = useWalletClient({ chainId })
 
   const [sdk, setSDK] = useState<GooddollarSavingsSDK | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState<boolean>(false)
 
-  if (!walletClient || !publicClient) {
-    return;
-  }
+  const isWrongNetwork = useMemo(
+    () => chainId !== undefined && !isSupportedChainId(chainId),
+    [chainId],
+  )
+
+  // Re-initialise the SDK when clients or chain change. Memoise the override
+  // map so identical option objects don't trigger spurious effects.
+  const contractsKey = useMemo(
+    () => JSON.stringify(options.contracts ?? {}),
+    [options.contracts],
+  )
 
   useEffect(() => {
-    if (!publicClient || !walletClient) {
+    if (!publicClient) {
       setSDK(null)
-      setError("Public or Wallet client not initialized")
+      setError(null)
+      return
+    }
+
+    if (isWrongNetwork) {
+      setSDK(null)
+      setError(
+        `Wrong network. Please switch to ${formatSupportedNetworkList()}.`,
+      )
       return
     }
 
@@ -26,20 +67,29 @@ export function useGooddollarSavings() {
     setLoading(true)
 
     try {
-      const sdk = new GooddollarSavingsSDK(
+      const next = new GooddollarSavingsSDK(
         publicClient,
-        walletClient,
-      );
-      setSDK(sdk)
-    } catch (err: any) {
+        walletClient ?? undefined,
+        { contracts: options.contracts },
+      )
+      setSDK(next)
+    } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err))
       setSDK(null)
     } finally {
       setLoading(false)
     }
+    // contractsKey captures override changes, options.contracts itself can be
+    // a fresh object on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [publicClient, walletClient, isWrongNetwork, contractsKey])
 
-
-  }, [publicClient, walletClient])
-
-  return { sdk, loading, error }
+  return {
+    sdk,
+    loading,
+    error,
+    isWrongNetwork,
+    chainId,
+    supportedChainIds: SUPPORTED_CHAIN_IDS,
+  }
 }

--- a/packages/savings-widget/README.md
+++ b/packages/savings-widget/README.md
@@ -2,6 +2,8 @@
 
 The `gooddollar-savings-widget` web component provides a simple and interactive way for users to stake their G$ tokens and earn.
 
+The widget supports the **Celo** and **XDC** networks. If the connected wallet is on any other chain, the widget shows a "Wrong network" banner and disables the action button until the user switches to one of the supported networks.
+
 ## Integratig The Component
 
 Can be used in any website, for a quick setup:
@@ -63,3 +65,6 @@ Customize the `gooddollar-savings-widget` using these properties:
 
 - **`web3Provider`**: _(Set via JavaScript property)_  
   The web3Provider object when the wallet is connected. Wallet connection logic should be handeled outside of this component.
+
+- **`default-chain-id`**: _(HTML attribute / JS property `defaultChainId`)_  
+  Numeric chain id used to display global stats when no wallet is connected. Must be one of the supported chains: `42220` (Celo, default) or `50` (XDC).

--- a/packages/savings-widget/src/GooddollarSavingsWidget.ts
+++ b/packages/savings-widget/src/GooddollarSavingsWidget.ts
@@ -1,15 +1,51 @@
-import { LitElement, html, css } from 'lit';
-import { customElement, property, state } from 'lit/decorators.js';
-import { createWalletClient, createPublicClient, custom, PublicClient, WalletClient, http, formatEther, parseEther } from 'viem'
-import { celo } from 'viem/chains';
-import { GooddollarSavingsSDK } from '@goodsdks/savings-sdk';
+import { LitElement, html, css } from "lit"
+import { customElement, property, state } from "lit/decorators.js"
+import {
+  createWalletClient,
+  createPublicClient,
+  custom,
+  PublicClient,
+  WalletClient,
+  http,
+  formatEther,
+  parseEther,
+} from "viem"
+import { celo, xdc, type Chain } from "viem/chains"
+import {
+  GooddollarSavingsSDK,
+  SUPPORTED_CHAIN_IDS,
+  SupportedChainId,
+  formatSupportedNetworkList,
+  isSupportedChainId,
+} from "@goodsdks/savings-sdk"
 
-@customElement('gooddollar-savings-widget')
+type AnyEip1193Provider = {
+  isConnected?: () => boolean
+  request: (args: { method: string; params?: unknown[] }) => Promise<unknown>
+  on?: (event: string, handler: (...args: unknown[]) => void) => void
+  removeListener?: (
+    event: string,
+    handler: (...args: unknown[]) => void,
+  ) => void
+}
+
+const CHAIN_BY_ID: Record<SupportedChainId, Chain> = {
+  [SupportedChainId.CELO]: celo,
+  [SupportedChainId.XDC]: xdc,
+}
+
+const CHAIN_LABEL: Record<SupportedChainId, string> = {
+  [SupportedChainId.CELO]: "Celo",
+  [SupportedChainId.XDC]: "XDC Network",
+}
+
+@customElement("gooddollar-savings-widget")
 export class GooddollarSavingsWidget extends LitElement {
   static styles = css`
     :host {
       display: block;
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      font-family:
+        -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
       max-width: 480px;
       margin: 0 auto;
     }
@@ -39,11 +75,11 @@ export class GooddollarSavingsWidget extends LitElement {
       justify-content: center;
     }
     .logo img {
-        width: 44px;
-        height: 44px;
-        box-shadow: rgba(0, 0, 0, 0.075) 0px 6px 10px;
-        border-radius: 50%;
-        background-color: white;
+      width: 44px;
+      height: 44px;
+      box-shadow: rgba(0, 0, 0, 0.075) 0px 6px 10px;
+      border-radius: 50%;
+      background-color: white;
     }
 
     .title {
@@ -180,6 +216,11 @@ export class GooddollarSavingsWidget extends LitElement {
       background: #0387c3;
     }
 
+    .main-button:disabled {
+      cursor: not-allowed;
+      opacity: 0.7;
+    }
+
     .main-button.primary {
       background: #00b0ff;
       color: white;
@@ -187,6 +228,14 @@ export class GooddollarSavingsWidget extends LitElement {
 
     .main-button.primary:hover {
       background: #0387c3;
+    }
+
+    .main-button.warning {
+      background: #f59e0b;
+    }
+
+    .main-button.warning:hover {
+      background: #d97706;
     }
 
     .stats-section {
@@ -251,92 +300,179 @@ export class GooddollarSavingsWidget extends LitElement {
       margin-top: 4px;
       padding-left: 4px;
     }
+
+    .network-banner {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 12px;
+      border-radius: 10px;
+      margin-bottom: 16px;
+      background: #fef3c7;
+      border: 1px solid #fbbf24;
+      color: #92400e;
+      font-size: 13px;
+      line-height: 1.4;
+    }
+
+    .network-banner strong {
+      font-weight: 600;
+    }
+
+    .chain-pill {
+      font-size: 12px;
+      font-weight: 600;
+      color: #0369a1;
+      background: #e0f2fe;
+      border: 1px solid #bae6fd;
+      border-radius: 999px;
+      padding: 2px 10px;
+      margin-left: auto;
+    }
   `
+
   @property({ type: Object })
-  web3Provider: any = null;
+  web3Provider: AnyEip1193Provider | null = null
 
   @property({ type: Function })
-  connectWallet: (() => void) | undefined = undefined;
+  connectWallet: (() => void) | undefined = undefined
+
+  /**
+   * Chain id used to display global stats when no wallet is connected.
+   * Defaults to Celo. Must be one of the supported chains.
+   */
+  @property({ type: Number, attribute: "default-chain-id" })
+  defaultChainId: SupportedChainId = SupportedChainId.CELO
 
   @state()
-  activeTab: string = 'stake';
+  activeTab: string = "stake"
 
   @state()
-  inputAmount: string = '0.0';
+  inputAmount: string = "0.0"
 
   @state()
-  walletBalance: bigint = BigInt(0);
+  walletBalance: bigint = BigInt(0)
 
   @state()
-  currentStake: bigint = BigInt(0);
+  currentStake: bigint = BigInt(0)
 
   @state()
-  unclaimedRewards: bigint = BigInt(0);
+  unclaimedRewards: bigint = BigInt(0)
 
   @state()
-  totalStaked: bigint = BigInt(0);
+  totalStaked: bigint = BigInt(0)
 
   @state()
-  userWeeklyRewards: bigint = BigInt(0);
+  userWeeklyRewards: bigint = BigInt(0)
 
   @state()
-  annualAPR: number = 0;
+  annualAPR: number = 0
 
   @state()
-  interval: NodeJS.Timeout | null = null;
+  interval: ReturnType<typeof setInterval> | null = null
 
   @state()
-  isLoading: boolean = false;
+  isLoading: boolean = false
 
   @state()
-  txLoading: boolean = false;
+  txLoading: boolean = false
 
   @state()
-  isClaiming: boolean = false;
+  isClaiming: boolean = false
 
   @state()
-  inputError: string = '';
+  inputError: string = ""
 
   @state()
-  transactionError: string = '';
+  transactionError: string = ""
 
-  private walletClient: WalletClient | null = null;
-  private publicClient: PublicClient | null = null;
-  private sdk: GooddollarSavingsSDK | null = null;
-  private userAddress: string | null = null;
+  /** Active chain id (from wallet when connected, otherwise the default). */
+  @state()
+  activeChainId: SupportedChainId = SupportedChainId.CELO
+
+  /** Wallet chain id, even when unsupported. `undefined` means not connected. */
+  @state()
+  walletChainId: number | undefined = undefined
+
+  private walletClient: WalletClient | null = null
+  private publicClients: Partial<Record<SupportedChainId, PublicClient>> = {}
+  private sdk: GooddollarSavingsSDK | null = null
+  private userAddress: string | null = null
+  private chainChangedHandler: ((chainIdHex: unknown) => void) | null = null
+  private accountsChangedHandler:
+    | ((accounts: unknown) => void)
+    | null = null
+  private trackedProvider: AnyEip1193Provider | null = null
 
   connectedCallback(): void {
-    super.connectedCallback();
-    this.interval = setInterval(
-      () => this.refreshData(),
-      30_000
-    );
-    this.refreshData();
+    super.connectedCallback()
+    this.activeChainId = isSupportedChainId(this.defaultChainId)
+      ? this.defaultChainId
+      : SupportedChainId.CELO
+    this.interval = setInterval(() => this.refreshData(), 30_000)
+    this.refreshData()
   }
   disconnectedCallback() {
     if (this.interval) {
-      clearInterval(this.interval);
+      clearInterval(this.interval)
     }
+    this.unsubscribeProvider()
+    super.disconnectedCallback()
   }
-  updated(changedProperties: Map<string, any>) {
-    if (changedProperties.has('web3Provider')) {
-      this.refreshData();
+  updated(changedProperties: Map<string, unknown>) {
+    if (changedProperties.has("web3Provider")) {
+      this.subscribeProvider()
+      this.refreshData()
     }
-    if (changedProperties.has('walletBalance') || changedProperties.has('currentStake')) {
-      this.validateInput();
+    if (changedProperties.has("defaultChainId") && !this.web3Provider) {
+      this.activeChainId = isSupportedChainId(this.defaultChainId)
+        ? this.defaultChainId
+        : SupportedChainId.CELO
+      this.refreshData()
+    }
+    if (
+      changedProperties.has("walletBalance") ||
+      changedProperties.has("currentStake")
+    ) {
+      this.validateInput()
     }
   }
 
   render() {
-    const isConnected = !!(this.web3Provider && this.web3Provider.isConnected && this.userAddress);
+    const isProviderConnected = !!(
+      this.web3Provider &&
+      (this.web3Provider.isConnected
+        ? this.web3Provider.isConnected()
+        : true) &&
+      this.userAddress
+    )
+    const isWrongNetwork =
+      isProviderConnected && !isSupportedChainId(this.walletChainId)
+    const isConnected = isProviderConnected && !isWrongNetwork
     return html`
       <div class="container">
         <div class="header">
           <div class="logo">
-            <img alt="G$ logo" src="https://raw.githubusercontent.com/GoodDollar/GoodDAPP/master/src/assets/Splash/logo.svg" >
+            <img
+              alt="G$ logo"
+              src="https://raw.githubusercontent.com/GoodDollar/GoodDAPP/master/src/assets/Splash/logo.svg"
+            />
           </div>
           <h1 class="title">Gooddollar Savings</h1>
+          <span class="chain-pill">${this.activeChainLabel()}</span>
         </div>
+
+        ${isWrongNetwork
+          ? html`
+              <div class="network-banner" role="alert">
+                <strong>Wrong network.</strong>
+                <span>
+                  Please switch your wallet to
+                  ${formatSupportedNetworkList()} to use Gooddollar Savings.
+                </span>
+              </div>
+            `
+          : ""}
 
         <div class="tab-container">
           <button
@@ -357,9 +493,16 @@ export class GooddollarSavingsWidget extends LitElement {
           <div class="balance-info ${!isConnected ? "hidden" : ""}">
             <span>
               ${this.activeTab === "stake"
-        ? `Wallet Balance: ${this.isLoading ? 'Loading...' : this.formatBigInt(this.walletBalance)}`
-        : `Current Stake: ${this.isLoading ? 'Loading...' : this.formatBigInt(this.currentStake)}`
-      }
+                ? `Wallet Balance: ${
+                    this.isLoading
+                      ? "Loading..."
+                      : this.formatBigInt(this.walletBalance)
+                  }`
+                : `Current Stake: ${
+                    this.isLoading
+                      ? "Loading..."
+                      : this.formatBigInt(this.currentStake)
+                  }`}
             </span>
           </div>
           <div class="input-container">
@@ -369,147 +512,318 @@ export class GooddollarSavingsWidget extends LitElement {
               .value=${this.inputAmount}
               @input=${this.handleInputChange}
               placeholder="0.0"
+              ?disabled=${isWrongNetwork}
             />
-            <button class="max-button" @click=${this.handleMaxClick}>Max</button>
+            <button
+              class="max-button"
+              @click=${this.handleMaxClick}
+              ?disabled=${isWrongNetwork}
+            >
+              Max
+            </button>
           </div>
-          ${this.inputError ? html`<div class="error-message">${this.inputError}</div>` : ''}
+          ${this.inputError
+            ? html`<div class="error-message">${this.inputError}</div>`
+            : ""}
         </div>
 
         <div class="rewards-section ${!isConnected ? "hidden" : ""}">
           <span class="rewards-label">Unclaimed Rewards</span>
           <div class="rewards-value">
-            <button class="claim-button" @click=${this.handleClaim} ?disabled=${this.isClaiming}>
-              ${this.isClaiming ? 'Claiming...' : 'Claim'}
+            <button
+              class="claim-button"
+              @click=${this.handleClaim}
+              ?disabled=${this.isClaiming || isWrongNetwork}
+            >
+              ${this.isClaiming ? "Claiming..." : "Claim"}
             </button>
-            <span>${this.isLoading ? 'Loading...' : this.formatBigInt(this.unclaimedRewards)}</span>
+            <span
+              >${this.isLoading
+                ? "Loading..."
+                : this.formatBigInt(this.unclaimedRewards)}</span
+            >
           </div>
         </div>
 
-        ${this.transactionError ? html`<div class="error-message" style="margin-bottom: 16px; text-align: center;">${this.transactionError}</div>` : ''}
-
-        ${!isConnected
-        ? html`
-          <button class="main-button primary" @click=${this.handleConnectWallet}>
-            Connect Wallet
-          </button>
-        `
-        : html`
-          <button
-            class="main-button"
-            @click=${this.activeTab === "stake" ? this.handleStake : this.handleUnstake}
-            ?disabled=${this.txLoading}
-          >
-            ${this.txLoading ? 'Processing...' : (this.activeTab === "stake" ? "Stake" : "Unstake")}
-          </button>
-        `
-      }
+        ${this.transactionError
+          ? html`<div
+              class="error-message"
+              style="margin-bottom: 16px; text-align: center;"
+            >
+              ${this.transactionError}
+            </div>`
+          : ""}
+        ${!isProviderConnected
+          ? html`
+              <button
+                class="main-button primary"
+                @click=${this.handleConnectWallet}
+              >
+                Connect Wallet
+              </button>
+            `
+          : isWrongNetwork
+            ? html`
+                <button class="main-button warning" disabled>
+                  Wrong Network
+                </button>
+              `
+            : html`
+                <button
+                  class="main-button"
+                  @click=${this.activeTab === "stake"
+                    ? this.handleStake
+                    : this.handleUnstake}
+                  ?disabled=${this.txLoading}
+                >
+                  ${this.txLoading
+                    ? "Processing..."
+                    : this.activeTab === "stake"
+                      ? "Stake"
+                      : "Unstake"}
+                </button>
+              `}
 
         <div class="stats-section">
           <h3 class="stats-title">Staking Statistics</h3>
 
           <div class="stat-row">
             <span class="stat-label">Total G$ Staked</span>
-            <span class="stat-value">${this.isLoading ? 'Loading...' : this.formatBigInt(this.totalStaked)}</span>
+            <span class="stat-value"
+              >${this.isLoading
+                ? "Loading..."
+                : this.formatBigInt(this.totalStaked)}</span
+            >
           </div>
 
           ${isConnected
-        ? html`
-            <div class="stat-row">
-              <span class="stat-label">Your G$ Stake Pool Share</span>
-              <span class="stat-value">${this.isLoading ? 'Loading...' : this.formatBigInt(this.currentStake)}</span>
-            </div>
+            ? html`
+                <div class="stat-row">
+                  <span class="stat-label">Your G$ Stake Pool Share</span>
+                  <span class="stat-value"
+                    >${this.isLoading
+                      ? "Loading..."
+                      : this.formatBigInt(this.currentStake)}</span
+                  >
+                </div>
 
-            <div class="stat-row">
-              <span class="stat-label">Your Weekly Rewards</span>
-              <span class="stat-value">${this.isLoading ? 'Loading...' : this.formatBigInt(this.userWeeklyRewards)}</span>
-            </div>
-          `
-        : ""
-      }
+                <div class="stat-row">
+                  <span class="stat-label">Your Weekly Rewards</span>
+                  <span class="stat-value"
+                    >${this.isLoading
+                      ? "Loading..."
+                      : this.formatBigInt(this.userWeeklyRewards)}</span
+                  >
+                </div>
+              `
+            : ""}
 
           <div class="stat-row">
             <span class="stat-label">Annual Stake APR</span>
-            <span class="stat-value">${this.isLoading ? 'Loading...' : this.formatPercent(this.annualAPR)}</span>
+            <span class="stat-value"
+              >${this.isLoading
+                ? "Loading..."
+                : this.formatPercent(this.annualAPR)}</span
+            >
           </div>
         </div>
-        ${this.txLoading || this.isClaiming ? html`<div class="overlay"></div>` : ''}
+        ${this.txLoading || this.isClaiming
+          ? html`<div class="overlay"></div>`
+          : ""}
       </div>
-    `;
+    `
+  }
+
+  private activeChainLabel(): string {
+    return CHAIN_LABEL[this.activeChainId] ?? "Unknown"
+  }
+
+  private getPublicClient(chainId: SupportedChainId): PublicClient {
+    let client = this.publicClients[chainId]
+    if (!client) {
+      client = createPublicClient({
+        chain: CHAIN_BY_ID[chainId],
+        transport: http(),
+      }) as unknown as PublicClient
+      this.publicClients[chainId] = client
+    }
+    return client
+  }
+
+  private subscribeProvider() {
+    this.unsubscribeProvider()
+    const provider = this.web3Provider
+    if (!provider || typeof provider.on !== "function") return
+
+    this.chainChangedHandler = () => {
+      void this.refreshData()
+    }
+    this.accountsChangedHandler = () => {
+      void this.refreshData()
+    }
+
+    provider.on("chainChanged", this.chainChangedHandler)
+    provider.on("accountsChanged", this.accountsChangedHandler)
+    this.trackedProvider = provider
+  }
+
+  private unsubscribeProvider() {
+    const provider = this.trackedProvider
+    if (!provider || typeof provider.removeListener !== "function") {
+      this.trackedProvider = null
+      this.chainChangedHandler = null
+      this.accountsChangedHandler = null
+      return
+    }
+    if (this.chainChangedHandler) {
+      provider.removeListener("chainChanged", this.chainChangedHandler)
+    }
+    if (this.accountsChangedHandler) {
+      provider.removeListener("accountsChanged", this.accountsChangedHandler)
+    }
+    this.chainChangedHandler = null
+    this.accountsChangedHandler = null
+    this.trackedProvider = null
+  }
+
+  private async readProviderChainId(
+    provider: AnyEip1193Provider,
+  ): Promise<number | undefined> {
+    try {
+      const chainIdHex = (await provider.request({
+        method: "eth_chainId",
+      })) as string
+      if (typeof chainIdHex === "string") {
+        return parseInt(chainIdHex, 16)
+      }
+      if (typeof chainIdHex === "number") {
+        return chainIdHex
+      }
+    } catch (error) {
+      console.warn("Failed to read provider chainId:", error)
+    }
+    return undefined
   }
 
   private async refreshData() {
-    if (!this.publicClient) {
-      this.publicClient = createPublicClient({
-        chain: celo,
-        transport: http()
-      }) as unknown as PublicClient;
+    const provider = this.web3Provider
+    const isProviderConnected = !!(
+      provider && (provider.isConnected ? provider.isConnected() : true)
+    )
+
+    if (!isProviderConnected) {
+      this.walletChainId = undefined
+      this.userAddress = null
+      this.walletClient = null
+      this.activeChainId = isSupportedChainId(this.defaultChainId)
+        ? this.defaultChainId
+        : SupportedChainId.CELO
+      this.resetUserStats()
+      this.sdk = new GooddollarSavingsSDK(
+        this.getPublicClient(this.activeChainId),
+      )
+      await this.loadStats()
+      return
     }
 
-    if (this.web3Provider && this.web3Provider.isConnected) {
-      this.walletClient = createWalletClient({
-        chain: celo,
-        transport: custom(this.web3Provider)
-      });
-      this.sdk = new GooddollarSavingsSDK(this.publicClient!, this.walletClient);
-      await this.loadStats();
+    const walletChainId = await this.readProviderChainId(provider!)
+    this.walletChainId = walletChainId
 
-      const accounts = await this.web3Provider.request({ method: 'eth_accounts' });
-      if (accounts.length > 0) {
-        this.userAddress = accounts[0];
-        await this.loadUserStats();
-      } else {
-        this.resetUserStats();
+    const accounts = (await provider!.request({
+      method: "eth_accounts",
+    })) as string[]
+    this.userAddress = accounts && accounts.length > 0 ? accounts[0] : null
+
+    if (!isSupportedChainId(walletChainId)) {
+      // Wrong network: keep showing global stats from the configured default
+      // chain so the widget remains informative, but don't try to read user
+      // balances from an incompatible chain.
+      this.walletClient = null
+      this.activeChainId = isSupportedChainId(this.defaultChainId)
+        ? this.defaultChainId
+        : SupportedChainId.CELO
+      this.resetUserStats()
+      try {
+        this.sdk = new GooddollarSavingsSDK(
+          this.getPublicClient(this.activeChainId),
+        )
+        await this.loadStats()
+      } catch (error) {
+        console.error("Error initialising SDK on default chain:", error)
       }
+      return
+    }
+
+    this.activeChainId = walletChainId
+    const chain = CHAIN_BY_ID[walletChainId]
+    this.walletClient = createWalletClient({
+      chain,
+      transport: custom(provider as unknown as Parameters<typeof custom>[0]),
+    })
+
+    try {
+      this.sdk = new GooddollarSavingsSDK(
+        this.getPublicClient(this.activeChainId),
+        this.walletClient,
+      )
+    } catch (error) {
+      console.error("Failed to initialise savings SDK:", error)
+      this.sdk = null
+      return
+    }
+
+    await this.loadStats()
+    if (this.userAddress) {
+      await this.loadUserStats()
     } else {
-      this.sdk = new GooddollarSavingsSDK(this.publicClient);
-      await this.loadStats();
+      this.resetUserStats()
     }
   }
 
   private async loadStats() {
-    if (!this.sdk) return;
+    if (!this.sdk) return
     try {
-      const globalStats = await this.sdk.getGlobalStats();
-      this.totalStaked = globalStats.totalStaked;
-      this.annualAPR = globalStats.annualAPR;
+      const globalStats = await this.sdk.getGlobalStats()
+      this.totalStaked = globalStats.totalStaked
+      this.annualAPR = globalStats.annualAPR
     } catch (error) {
-      console.error('Error loading global stats:', error);
+      console.error("Error loading global stats:", error)
     }
   }
 
   private async loadUserStats() {
-    if (!this.sdk || !this.userAddress) return;
+    if (!this.sdk || !this.userAddress) return
     try {
       const userStats = await this.sdk.getUserStats()
-      this.walletBalance = userStats.walletBalance;
-      this.currentStake = userStats.currentStake;
-      this.unclaimedRewards = userStats.unclaimedRewards;
-      this.userWeeklyRewards = userStats.userWeeklyRewards;
+      this.walletBalance = userStats.walletBalance
+      this.currentStake = userStats.currentStake
+      this.unclaimedRewards = userStats.unclaimedRewards
+      this.userWeeklyRewards = userStats.userWeeklyRewards
     } catch (error) {
-      console.error('Error loading user stats:', error);
+      console.error("Error loading user stats:", error)
     }
   }
   private resetUserStats() {
-    this.walletBalance = 0n;
-    this.currentStake = 0n;
-    this.unclaimedRewards = 0n;
-    this.userWeeklyRewards = 0n;
+    this.walletBalance = 0n
+    this.currentStake = 0n
+    this.unclaimedRewards = 0n
+    this.userWeeklyRewards = 0n
   }
 
   formatBigInt(num: bigint) {
-    return Intl.NumberFormat().format(this.toEtherNumber(num));
+    return Intl.NumberFormat().format(this.toEtherNumber(num))
   }
   toEtherNumber(num: bigint) {
-    return Number(formatEther(num));
+    return Number(formatEther(num))
   }
   formatPercent(num: number) {
-    return `${num.toFixed(2)}%`;
+    return `${num.toFixed(2)}%`
   }
 
   handleTabClick(tab: string) {
-    this.activeTab = tab;
-    this.inputError = '';
-    this.transactionError = '';
+    this.activeTab = tab
+    this.inputError = ""
+    this.transactionError = ""
   }
 
   handleMaxClick() {
@@ -518,129 +832,149 @@ export class GooddollarSavingsWidget extends LitElement {
     } else {
       this.inputAmount = this.toEtherNumber(this.currentStake).toString()
     }
-    this.inputError = '';
+    this.inputError = ""
   }
 
   handleInputChange(e: Event) {
-    const input = e.target as HTMLInputElement;
-    this.inputAmount = input.value;
-    this.validateInput();
+    const input = e.target as HTMLInputElement
+    this.inputAmount = input.value
+    this.validateInput()
   }
 
   private validateInput(force: boolean = false) {
-    this.inputError = '';
-    if (!this.inputAmount || this.inputAmount.trim() === '') {
-      return;
+    this.inputError = ""
+    if (!this.inputAmount || this.inputAmount.trim() === "") {
+      return
     }
 
-    // Check for invalid characters (only numbers and decimal point allowed)
-    const validInputRegex = /^[0-9]*\.?[0-9]*$/;
+    const validInputRegex = /^[0-9]*\.?[0-9]*$/
     if (!validInputRegex.test(this.inputAmount)) {
-      this.inputError = 'Invalid value';
-      return;
+      this.inputError = "Invalid value"
+      return
     }
 
-    const numValue = parseFloat(this.inputAmount);
+    const numValue = parseFloat(this.inputAmount)
     if (isNaN(numValue) || numValue < 0) {
-      this.inputError = 'Invalid value';
-      return;
+      this.inputError = "Invalid value"
+      return
     }
     if (numValue === 0 && force) {
-      this.inputError = 'Please enter a valid amount';
-      return;
+      this.inputError = "Please enter a valid amount"
+      return
     }
 
-    if (this.activeTab === 'stake') {
-      const inputAmountWei = parseEther(this.inputAmount);
+    if (this.activeTab === "stake") {
+      const inputAmountWei = parseEther(this.inputAmount)
       if (inputAmountWei > this.walletBalance) {
-        this.inputError = 'Insufficient balance';
-        return;
+        this.inputError = "Insufficient balance"
+        return
       }
     }
 
-    if (this.activeTab === 'unstake') {
-      const inputAmountWei = parseEther(this.inputAmount);
+    if (this.activeTab === "unstake") {
+      const inputAmountWei = parseEther(this.inputAmount)
       if (inputAmountWei > this.currentStake) {
-        this.inputError = 'Max amount exceeded';
-        return;
+        this.inputError = "Max amount exceeded"
+        return
       }
     }
   }
 
   handleConnectWallet() {
     if (this.connectWallet) {
-      this.connectWallet();
+      this.connectWallet()
     }
   }
 
+  private isOnSupportedChain(): boolean {
+    return isSupportedChainId(this.walletChainId)
+  }
+
   async handleStake() {
-    if (!this.sdk || !this.userAddress) return;
-    this.validateInput(true);
+    if (!this.sdk || !this.userAddress) return
+    if (!this.isOnSupportedChain()) {
+      this.transactionError = `Please switch to ${formatSupportedNetworkList()}.`
+      return
+    }
+    this.validateInput(true)
     if (this.inputError) {
-      return;
+      return
     }
 
     try {
-      this.txLoading = true;
-      this.transactionError = '';
-      const amount = parseEther(this.inputAmount);
-      const receipt = await this.sdk.stake(amount);
-      if (receipt.status === 'success') {
-        await this.refreshData();
-        this.inputAmount = '0.0';
-        this.inputError = '';
-        this.transactionError = '';
+      this.txLoading = true
+      this.transactionError = ""
+      const amount = parseEther(this.inputAmount)
+      const receipt = await this.sdk.stake(amount)
+      if (receipt.status === "success") {
+        await this.refreshData()
+        this.inputAmount = "0.0"
+        this.inputError = ""
+        this.transactionError = ""
       }
-    } catch (error: any) {
-      console.error('Staking error:', error);
-      this.transactionError = error.message || 'Staking failed';
+    } catch (error: unknown) {
+      console.error("Staking error:", error)
+      this.transactionError =
+        error instanceof Error ? error.message : "Staking failed"
     } finally {
-      this.txLoading = false;
+      this.txLoading = false
     }
   }
 
   async handleUnstake() {
-    if (!this.sdk || !this.userAddress) return;
-    this.validateInput(true);
+    if (!this.sdk || !this.userAddress) return
+    if (!this.isOnSupportedChain()) {
+      this.transactionError = `Please switch to ${formatSupportedNetworkList()}.`
+      return
+    }
+    this.validateInput(true)
     if (this.inputError) {
-      return;
+      return
     }
 
     try {
-      this.txLoading = true;
-      this.transactionError = '';
-      const amount = parseEther(this.inputAmount);
-      const receipt = await this.sdk.unstake(amount);
-      if (receipt.status === 'success') {
-        await this.refreshData();
-        this.inputAmount = '0.0';
-        this.inputError = '';
-        this.transactionError = '';
+      this.txLoading = true
+      this.transactionError = ""
+      const amount = parseEther(this.inputAmount)
+      const receipt = await this.sdk.unstake(amount)
+      if (receipt.status === "success") {
+        await this.refreshData()
+        this.inputAmount = "0.0"
+        this.inputError = ""
+        this.transactionError = ""
       }
-    } catch (error: any) {
-      console.error('Unstaking error:', error);
-      this.transactionError = error.message || 'Unstaking failed';
+    } catch (error: unknown) {
+      console.error("Unstaking error:", error)
+      this.transactionError =
+        error instanceof Error ? error.message : "Unstaking failed"
     } finally {
-      this.txLoading = false;
+      this.txLoading = false
     }
   }
 
   async handleClaim() {
-    if (!this.sdk || !this.userAddress) return;
+    if (!this.sdk || !this.userAddress) return
+    if (!this.isOnSupportedChain()) {
+      this.transactionError = `Please switch to ${formatSupportedNetworkList()}.`
+      return
+    }
 
     try {
-      this.isClaiming = true;
-      this.transactionError = '';
-      const receipt = await this.sdk.claimReward();
-      if (receipt.status === 'success') {
-        await this.refreshData();
-        this.transactionError = '';
+      this.isClaiming = true
+      this.transactionError = ""
+      const receipt = await this.sdk.claimReward()
+      if (receipt.status === "success") {
+        await this.refreshData()
+        this.transactionError = ""
       }
-    } catch (error: any) {
-      console.error('Claim error:', error);
-      this.transactionError = error.message || 'Claim failed';
+    } catch (error: unknown) {
+      console.error("Claim error:", error)
+      this.transactionError =
+        error instanceof Error ? error.message : "Claim failed"
     } finally {
-      this.isClaiming = false;
+      this.isClaiming = false
     }
   }
 }
+
+export { SUPPORTED_CHAIN_IDS, SupportedChainId }


### PR DESCRIPTION
For the savings widget, XDC network support is added

## Summary by Sourcery

Add multi-chain (Celo and XDC) support to the Gooddollar savings SDK and widget, including network-aware UX and configuration.

New Features:
- Enable the savings widget to operate on both Celo and XDC networks with a configurable default chain and visible active network label.
- Expose supported chain metadata and contract configuration through a new constants module and SDK options, including per-chain contract overrides.
- Extend the Wagmi React hook to surface network state (current chain, supported chains, and wrong-network detection) alongside the SDK instance.

Enhancements:
- Handle wallet provider chain/account changes in the widget, showing a wrong-network banner and disabling staking actions when connected to unsupported chains.
- Refactor the SDK to validate client chain IDs, derive contract addresses per chain, and provide clearer errors for unsupported or mismatched networks.

Documentation:
- Update the savings widget README to document Celo/XDC support, wrong-network behavior, and the new default-chain-id configuration option.