### PR TITLE
test: cover connected account claim entitlement

### DIFF
--- a/packages/citizen-sdk/test/claim-connected-account.test.ts
+++ b/packages/citizen-sdk/test/claim-connected-account.test.ts
@@ -80,6 +80,9 @@ describe("ClaimSDK connected account entitlement checks", () => {
       status: "can_claim",
       entitlement: 456n,
     })
+    expect(identitySDK.getWhitelistedRoot).toHaveBeenCalledWith(
+      CONNECTED_ACCOUNT,
+    )
     expect(publicClient.readContract).toHaveBeenCalledWith(
       expect.objectContaining({
         functionName: "checkEntitlement",

--- a/packages/citizen-sdk/test/claim-connected-account.test.ts
+++ b/packages/citizen-sdk/test/claim-connected-account.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest"
+import type { PublicClient, WalletClient } from "viem"
+import { ClaimSDK } from "../src/sdks/viem-claim-sdk"
+import { SupportedChains } from "../src/constants"
+
+const CONNECTED_ACCOUNT = "0x2222222222222222222222222222222222222222"
+const ROOT_ACCOUNT = "0x1111111111111111111111111111111111111111"
+
+describe("ClaimSDK connected account entitlement checks", () => {
+  it("checks entitlement against the whitelisted root instead of the connected wallet", async () => {
+    const publicClient = {
+      readContract: vi.fn().mockResolvedValue(123n),
+    }
+
+    const walletClient = {
+      account: { address: CONNECTED_ACCOUNT },
+      chain: { id: SupportedChains.CELO },
+      getAddresses: vi.fn().mockResolvedValue([CONNECTED_ACCOUNT]),
+    }
+
+    const identitySDK = {
+      getWhitelistedRoot: vi.fn().mockResolvedValue({
+        isWhitelisted: true,
+        root: ROOT_ACCOUNT,
+      }),
+    }
+
+    const sdk = new ClaimSDK({
+      account: CONNECTED_ACCOUNT,
+      publicClient: publicClient as unknown as PublicClient,
+      walletClient: walletClient as unknown as WalletClient,
+      identitySDK: identitySDK as any,
+      env: "development",
+    })
+
+    const result = await sdk.checkEntitlement()
+
+    expect(result.amount).toBe(123n)
+    expect(identitySDK.getWhitelistedRoot).toHaveBeenCalledWith(
+      CONNECTED_ACCOUNT,
+    )
+    expect(publicClient.readContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        functionName: "checkEntitlement",
+        args: [ROOT_ACCOUNT],
+        account: CONNECTED_ACCOUNT,
+      }),
+    )
+  })
+
+  it("uses the same root-address entitlement path when resolving wallet claim status", async () => {
+    const publicClient = {
+      readContract: vi.fn().mockResolvedValue(456n),
+    }
+
+    const walletClient = {
+      account: { address: CONNECTED_ACCOUNT },
+      chain: { id: SupportedChains.CELO },
+      getAddresses: vi.fn().mockResolvedValue([CONNECTED_ACCOUNT]),
+    }
+
+    const identitySDK = {
+      getWhitelistedRoot: vi.fn().mockResolvedValue({
+        isWhitelisted: true,
+        root: ROOT_ACCOUNT,
+      }),
+    }
+
+    const sdk = new ClaimSDK({
+      account: CONNECTED_ACCOUNT,
+      publicClient: publicClient as unknown as PublicClient,
+      walletClient: walletClient as unknown as WalletClient,
+      identitySDK: identitySDK as any,
+      env: "development",
+    })
+
+    const status = await sdk.getWalletClaimStatus()
+
+    expect(status).toEqual({
+      status: "can_claim",
+      entitlement: 456n,
+    })
+    expect(publicClient.readContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        functionName: "checkEntitlement",
+        args: [ROOT_ACCOUNT],
+        account: CONNECTED_ACCOUNT,
+      }),
+    )
+  })
+})


### PR DESCRIPTION
Adds focused regression coverage for the connected-wallet claim path.

What changed:
- verifies `ClaimSDK.checkEntitlement()` resolves `getWhitelistedRoot(connectedAccount)` first
- verifies the SDK calls `checkEntitlement(address)` with the resolved root account, while keeping the connected wallet as the active account
- covers the same behavior through `getWalletClaimStatus()`

Why:
- issue #24 is specifically about connected wallets claiming through their whitelisted root identity
- current `main` already has the core root-address entitlement path, so this locks that behavior down without changing runtime code unnecessarily

Validation:
- `HOME=$PWD/.yarn-home YARN_GLOBAL_FOLDER=$PWD/.yarn-home/global YARN_CACHE_FOLDER=$PWD/.yarn/cache node .yarn/releases/yarn-4.6.0.cjs workspace @goodsdks/citizen-sdk vitest run test/claim-connected-account.test.ts`
- `HOME=$PWD/.yarn-home YARN_GLOBAL_FOLDER=$PWD/.yarn-home/global YARN_CACHE_FOLDER=$PWD/.yarn/cache node .yarn/releases/yarn-4.6.0.cjs workspace @goodsdks/citizen-sdk build`

Closes #24

## Summary by Sourcery

Add regression tests to verify connected wallets check claim entitlement against their whitelisted root account.

Tests:
- Add coverage ensuring ClaimSDK.checkEntitlement() resolves entitlement using the whitelisted root account while retaining the connected wallet as the active account.
- Add tests confirming getWalletClaimStatus() uses the same root-address entitlement path for connected accounts.