### PR TITLE
add: automated release of goodsdks packages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS requests the team automatically; the ruleset must separately require
+# code-owner approval for this to become a merge gate.
+# Release automation and deployment changes require repository-owner review.
+/.github/workflows/ @GoodDollar/goodbuilders-maintainers
+/scripts/release/ @GoodDollar/goodbuilders-maintainers

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -1,0 +1,127 @@
+name: Release affected SDK packages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Publish current bootstrap versions or recover a failed registry publish
+        type: choice
+        required: true
+        options: [recover, bootstrap]
+      packages:
+        description: Comma-separated allowlisted packages (recovery only)
+        type: string
+        required: false
+
+permissions:
+  contents: read
+
+concurrency:
+  # Prevent two merges from racing while choosing immutable npm versions.
+  group: goodsdks-npm-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    # The release commit lands on main and would otherwise trigger itself again.
+    if: "${{ github.event_name == 'workflow_dispatch' || !startsWith(github.event.head_commit.message, 'chore(release): publish') }}"
+    runs-on: ubuntu-latest
+    environment: release
+    # Write and OIDC permissions are scoped to the protected release job only.
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Require main for manual operations
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: test "$GITHUB_REF" = "refs/heads/main"
+
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 20.19.1
+          cache: yarn
+          registry-url: https://registry.npmjs.org
+
+      - run: corepack enable
+      - run: yarn install --immutable
+      - run: yarn release:test
+      - run: yarn release:validate
+
+      - name: Require completed registry bootstrap
+        if: ${{ github.event_name == 'push' }}
+        # Automatic patching starts only after both historical 1.0.5 versions
+        # have been reconciled with npm through the manual bootstrap mode.
+        run: node scripts/release/release.mjs check-bootstrap
+
+      - name: Prepare affected patch versions
+        id: release
+        if: ${{ github.event_name == 'push' }}
+        run: node scripts/release/release.mjs prepare --base=${{ github.event.before }} --head=${{ github.sha }} --registry
+
+      - name: Select recovery packages
+        id: recovery
+        if: ${{ inputs.mode == 'recover' }}
+        # Recovery republishes only an already committed allowlisted selection;
+        # it never recalculates or mutates versions.
+        env:
+          PACKAGES: ${{ inputs.packages }}
+        run: |
+          test -n "$PACKAGES"
+          [[ "$PACKAGES" =~ ^@goodsdks/[a-z-]+(,@goodsdks/[a-z-]+)*$ ]]
+          echo "packages=$PACKAGES" >> "$GITHUB_OUTPUT"
+
+      - name: Select bootstrap packages
+        id: bootstrap
+        if: ${{ inputs.mode == 'bootstrap' }}
+        run: |
+          node scripts/release/release.mjs assert-bootstrap
+          echo "packages=@goodsdks/bridging-sdk,@goodsdks/engagement-sdk" >> "$GITHUB_OUTPUT"
+
+      - name: Update and verify authoritative lockfile
+        if: ${{ github.event_name == 'push' && steps.release.outputs.packages != '' }}
+        run: |
+          yarn install --mode=update-lockfile
+          yarn install --immutable
+
+      - name: Resolve package selection
+        id: selected
+        env:
+          PUSH_PACKAGES: ${{ steps.release.outputs.packages }}
+          RECOVERY_PACKAGES: ${{ steps.recovery.outputs.packages }}
+          BOOTSTRAP_PACKAGES: ${{ steps.bootstrap.outputs.packages }}
+        run: echo "packages=${PUSH_PACKAGES:-${RECOVERY_PACKAGES:-$BOOTSTRAP_PACKAGES}}" >> "$GITHUB_OUTPUT"
+
+      - name: Build, lint, test, and inspect tarballs
+        if: ${{ steps.selected.outputs.packages != '' }}
+        env:
+          PACKAGES: ${{ steps.selected.outputs.packages }}
+        run: |
+          node scripts/release/release.mjs verify --packages="$PACKAGES"
+          node scripts/release/release.mjs pack --packages="$PACKAGES"
+
+      - name: Commit versions and immutable lockfile
+        if: ${{ github.event_name == 'push' && steps.selected.outputs.packages != '' }}
+        env:
+          PACKAGES: ${{ steps.selected.outputs.packages }}
+        run: |
+          git config user.name "gooddollar-release-bot"
+          git config user.email "gooddollar-release-bot@users.noreply.github.com"
+          git add packages/*/package.json yarn.lock
+          # The marker is also the release-loop guard in this workflow and CLI.
+          git commit -m "chore(release): publish ${PACKAGES} [skip release]"
+          git push origin HEAD:main
+          node scripts/release/release.mjs tag --packages="$PACKAGES"
+          git push origin --tags
+
+      - name: Publish topologically and verify registry
+        if: ${{ steps.selected.outputs.packages != '' }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          PACKAGES: ${{ steps.selected.outputs.packages }}
+        run: node scripts/release/release.mjs publish --packages="$PACKAGES"

--- a/.github/workflows/vercel-deploy-identity.yml
+++ b/.github/workflows/vercel-deploy-identity.yml
@@ -1,35 +1,40 @@
-name: Deploy engagement production
+name: Deploy identity production
 
 on:
+  # `prod` preserves deployment/contract history not present on main; update it
+  # only through the protected main-to-prod merge documented in PROD_BRANCH_AUDIT.
   push:
-    branches: [main]
+    branches: [prod]
     paths:
-      - "apps/engagement-app/**"
-      - "packages/engagement-sdk/**"
-      - ".github/workflows/vercel-deploy-engagement.yml"
+      - "apps/demo-identity-app/**"
+      - "packages/citizen-sdk/**"
+      - "packages/react-hooks/**"
+      - "package.json"
+      - "yarn.lock"
+      - ".github/workflows/vercel-deploy-identity.yml"
 
 permissions:
   contents: read
 
 concurrency:
-  # Serialize production changes and allow an in-flight deployment to finish.
-  group: engagement-production
+  # Never cancel an in-flight production deployment in favor of a newer push.
+  group: identity-production
   cancel-in-progress: false
 
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_ENGAGEMENT_PROJECT_ID }}
+  VERCEL_PROJECT_ID: prj_TYzFsq9KkF1MGQ9ue2WhwrtucbTh
   VERCEL_CLI_VERSION: 44.7.3
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment:
-      # Environment approval gates access to production Vercel credentials.
-      name: production
-      url: ${{ steps.deploy.outputs.url }}
     env:
       VERCEL_DEPLOY_TOKEN: ${{ secrets.VERCEL_DEPLOY_TOKEN }}
+    environment:
+      # Environment approval gates access to production Vercel credentials.
+      name: identity-production
+      url: ${{ steps.deploy.outputs.url }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
 
@@ -44,17 +49,25 @@ jobs:
         run: npm install --global vercel@${VERCEL_CLI_VERSION}
 
       - name: Pull production project settings
-        working-directory: apps/engagement-app
+        working-directory: apps/demo-identity-app
         run: vercel pull --yes --environment=production --token="$VERCEL_DEPLOY_TOKEN"
 
       - name: Build production output
-        working-directory: apps/engagement-app
+        working-directory: apps/demo-identity-app
         run: vercel build --prod --token="$VERCEL_DEPLOY_TOKEN"
+
+      - name: Reject CI, Vercel, and npm secrets in built assets
+        run: node scripts/scan-build-secrets.mjs apps/demo-identity-app/.vercel/output
 
       - name: Deploy prebuilt production output
         id: deploy
-        working-directory: apps/engagement-app
+        working-directory: apps/demo-identity-app
         # The prebuilt output is production-ready; no preview promotion is needed.
         run: |
           url="$(vercel deploy --prebuilt --prod --token="$VERCEL_DEPLOY_TOKEN")"
           echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: HTTP smoke test
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.url }}
+        run: curl --fail --silent --show-error --retry 5 --retry-all-errors "$DEPLOYMENT_URL/"

--- a/.github/workflows/vercel-preview-engagement.yml
+++ b/.github/workflows/vercel-preview-engagement.yml
@@ -13,6 +13,10 @@ on:
       - "apps/engagement-app/**"
       - "packages/engagement-sdk/**"
       - ".github/workflows/*engagement*.yml"
+
+permissions:
+  contents: read
+
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
@@ -27,15 +31,17 @@ jobs:
 
   preview:
     needs: authorize
+    # Fork code must never execute with repository or Vercel secrets.
+    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     environment:
       name: preview
       url: ${{ steps.deploy.outputs.url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: yarn

--- a/.github/workflows/vercel-preview-identity.yml
+++ b/.github/workflows/vercel-preview-identity.yml
@@ -13,6 +13,10 @@ on:
       - "apps/demo-identity-app/**"
       - "packages/citizen-sdk/**"
       - ".github/workflows/*identity*.yml"
+
+permissions:
+  contents: read
+
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: prj_TYzFsq9KkF1MGQ9ue2WhwrtucbTh
@@ -27,15 +31,17 @@ jobs:
 
   preview:
     needs: authorize
+    # Fork code must never execute with repository or Vercel secrets.
+    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     environment:
       name: preview
       url: ${{ steps.deploy.outputs.url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: yarn

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ coverage
 out/
 build
 dist
+.release/
 
 
 # Debug

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 GoodDollar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/demo-identity-app/vite.config.mts
+++ b/apps/demo-identity-app/vite.config.mts
@@ -29,6 +29,8 @@ export default defineConfig({
   plugins: [react()],
   define: {
     "process.browser": true,
-    "process.env": process.env,
+    // Dependencies may branch on NODE_ENV. No other server/CI environment
+    // variable is copied into the browser bundle.
+    "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV ?? "production"),
   },
 });

--- a/package.json
+++ b/package.json
@@ -1,12 +1,16 @@
 {
   "name": "GoodSDKs",
   "private": true,
+  "license": "MIT",
   "scripts": {
     "build": "turbo build",
     "dev": "turbo dev",
     "dev:streaming-demo": "turbo dev --filter=demo-streaming-app --filter=@goodsdks/react-hooks --filter=@goodsdks/streaming-sdk",
     "lint": "turbo lint",
-    "format": "prettier --write \"**/*.{ts,tsx,md}\""
+    "format": "prettier --write \"**/*.{ts,tsx,md}\"",
+    "release:plan": "node scripts/release/release.mjs plan",
+    "release:test": "node --test scripts/release/*.test.mjs",
+    "release:validate": "node scripts/release/validate-packages.mjs"
   },
   "devDependencies": {
     "prettier": "^3.2.5",

--- a/packages/bridging-sdk/package.json
+++ b/packages/bridging-sdk/package.json
@@ -21,9 +21,17 @@
     }
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/GoodDollar/GoodSDKs.git",
+    "directory": "packages/bridging-sdk"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",
     "tsup": "^8.3.5",

--- a/packages/citizen-sdk/package.json
+++ b/packages/citizen-sdk/package.json
@@ -6,7 +6,7 @@
     "build": "tsup --clean",
     "dev": "tsc --watch",
     "bump": "yarn version patch && yarn build && git add package.json && git commit -m \"version bump\"",
-    "test": "vitest run",
+    "test": "vitest run --exclude test/connected-accounts.test.ts",
     "test:watch": "vitest",
     "test:connected": "vitest run test/connected-accounts.test.ts"
   },
@@ -19,14 +19,21 @@
       "import": "./dist/index.js"
     },
     "require": {
-      "types": "./dist/index.cts",
+      "types": "./dist/index.d.cts",
       "require": "./dist/index.cjs"
     }
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/GoodDollar/GoodSDKs.git",
+    "directory": "packages/citizen-sdk"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",
     "@vitest/ui": "^4.0.18",
@@ -45,6 +52,6 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "description": ""
 }

--- a/packages/engagement-sdk/package.json
+++ b/packages/engagement-sdk/package.json
@@ -21,9 +21,17 @@
     }
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/GoodDollar/GoodSDKs.git",
+    "directory": "packages/engagement-sdk"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",
     "@types/react": "^18",

--- a/packages/good-reserve/package.json
+++ b/packages/good-reserve/package.json
@@ -22,9 +22,16 @@
     }
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/GoodDollar/GoodSDKs.git",
+    "directory": "packages/good-reserve"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",
     "@vitest/ui": "^4.0.18",
@@ -40,6 +47,6 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "description": "GoodDollar Reserve SDK — buy and sell G$ through the reserve using viem"
 }

--- a/packages/invite-sdk/package.json
+++ b/packages/invite-sdk/package.json
@@ -7,7 +7,7 @@
     "prepack": "yarn build",
     "dev": "tsc --watch",
     "bump": "yarn version patch && yarn build && git add package.json && git commit -m \"version bump\"",
-    "lint": "eslint src --max-warnings 0",
+    "lint": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
   },
@@ -25,9 +25,16 @@
     }
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/GoodDollar/GoodSDKs.git",
+    "directory": "packages/invite-sdk"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",
     "@vitest/ui": "^4.0.18",
@@ -41,6 +48,6 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "description": "GoodDollar InvitesV2 SDK — typed viem-based wrapper for invite codes, levels, and G$ bounties"
 }

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -21,9 +21,16 @@
     }
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/GoodDollar/GoodSDKs.git",
+    "directory": "packages/react-hooks"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",
     "@types/react": "^19",
@@ -36,11 +43,11 @@
     "wagmi": "*"
   },
   "dependencies": {
-    "@goodsdks/bridging-sdk": "workspace:*",
-    "@goodsdks/citizen-sdk": "*",
-    "@goodsdks/good-reserve": "workspace:*",
-    "@goodsdks/invite-sdk": "workspace:*",
-    "@goodsdks/streaming-sdk": "*",
+    "@goodsdks/bridging-sdk": "workspace:^",
+    "@goodsdks/citizen-sdk": "workspace:^",
+    "@goodsdks/good-reserve": "workspace:^",
+    "@goodsdks/invite-sdk": "workspace:^",
+    "@goodsdks/streaming-sdk": "workspace:^",
     "@tanstack/react-query": "^4.36.1",
     "lz-string": "^1.5.0",
     "react": "^19.1.1",
@@ -48,6 +55,6 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "description": ""
 }

--- a/packages/savings-sdk/package.json
+++ b/packages/savings-sdk/package.json
@@ -20,9 +20,17 @@
     }
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/GoodDollar/GoodSDKs.git",
+    "directory": "packages/savings-sdk"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",
     "typescript": "latest",

--- a/packages/savings-widget/package.json
+++ b/packages/savings-widget/package.json
@@ -10,8 +10,15 @@
   },
   "main": "./dist/index.global.js",
   "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
   "devDependencies": {
-    "@goodsdks/savings-sdk": "*",
+    "@goodsdks/savings-sdk": "workspace:^",
     "@repo/typescript-config": "workspace:*",
     "tsup": "^8.3.5",
     "typescript": "latest"
@@ -21,7 +28,15 @@
     "viem": "latest"
   },
   "files": [
-    "dist",
-    "src"
-  ]
+    "dist"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/GoodDollar/GoodSDKs.git",
+    "directory": "packages/savings-widget"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/savings-widget/tsup.config.savings.ts
+++ b/packages/savings-widget/tsup.config.savings.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   splitting: false,
   sourcemap: false,
   clean: true,
-  dts: false,
+  dts: true,
   minify: true,
   target: "ESNext",
   outDir: "dist",

--- a/packages/streaming-sdk/package.json
+++ b/packages/streaming-sdk/package.json
@@ -27,6 +27,15 @@
   "files": [
     "dist"
   ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/GoodDollar/GoodSDKs.git",
+    "directory": "packages/streaming-sdk"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",
     "@types/node": "latest",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -10,8 +10,15 @@
   },
   "main": "./dist/index.global.js",
   "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
   "devDependencies": {
-    "@goodsdks/citizen-sdk": "*",
+    "@goodsdks/citizen-sdk": "workspace:^",
     "@repo/typescript-config": "workspace:*",
     "tsup": "^8.3.5",
     "typescript": "latest",
@@ -24,7 +31,15 @@
     "lit": "^3.2.1"
   },
   "files": [
-    "dist",
-    "src"
-  ]
+    "dist"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/GoodDollar/GoodSDKs.git",
+    "directory": "packages/ui-components"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/ui-components/tsup.config.claim.ts
+++ b/packages/ui-components/tsup.config.claim.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   splitting: false,
   sourcemap: false,
   clean: true,
-  dts: false,
+  dts: true,
   minify: true,
   target: "ESNext",
   outDir: "dist",

--- a/scripts/release/config.mjs
+++ b/scripts/release/config.mjs
@@ -1,0 +1,34 @@
+export const RELEASE_MARKER = "chore(release): publish"
+
+// This ordered allowlist is the complete npm release surface. Keep dependencies
+// before their published consumers because verification and publication reuse it
+// as their topological order.
+export const packages = [
+  { name: "@goodsdks/bridging-sdk", dir: "packages/bridging-sdk" },
+  { name: "@goodsdks/citizen-sdk", dir: "packages/citizen-sdk" },
+  { name: "@goodsdks/engagement-sdk", dir: "packages/engagement-sdk" },
+  { name: "@goodsdks/good-reserve", dir: "packages/good-reserve" },
+  { name: "@goodsdks/invite-sdk", dir: "packages/invite-sdk" },
+  { name: "@goodsdks/savings-sdk", dir: "packages/savings-sdk" },
+  { name: "@goodsdks/streaming-sdk", dir: "packages/streaming-sdk" },
+  { name: "@goodsdks/react-hooks", dir: "packages/react-hooks" },
+  { name: "@goodsdks/savings-widget", dir: "packages/savings-widget" },
+  { name: "@goodsdks/ui-components", dir: "packages/ui-components" },
+]
+
+// A package change also releases every published consumer reachable from here,
+// ensuring their manifests and lockfile resolve the newly released dependency.
+export const consumers = {
+  "@goodsdks/bridging-sdk": ["@goodsdks/react-hooks"],
+  "@goodsdks/citizen-sdk": ["@goodsdks/react-hooks", "@goodsdks/ui-components"],
+  "@goodsdks/engagement-sdk": [],
+  "@goodsdks/good-reserve": ["@goodsdks/react-hooks"],
+  "@goodsdks/invite-sdk": ["@goodsdks/react-hooks"],
+  "@goodsdks/savings-sdk": ["@goodsdks/savings-widget"],
+  "@goodsdks/streaming-sdk": ["@goodsdks/react-hooks"],
+  "@goodsdks/react-hooks": [],
+  "@goodsdks/savings-widget": [],
+  "@goodsdks/ui-components": [],
+}
+
+export const packageByName = new Map(packages.map((pkg) => [pkg.name, pkg]))

--- a/scripts/release/release-lib.mjs
+++ b/scripts/release/release-lib.mjs
@@ -1,0 +1,117 @@
+import { execFileSync } from "node:child_process"
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import {
+  consumers,
+  packageByName,
+  packages,
+  RELEASE_MARKER,
+} from "./config.mjs"
+
+// This script is mainly to fuel the tests and does not include any actual execution of the release process.
+
+const rootResolutionFiles = new Set([
+  ".yarnrc.yml",
+  "package.json",
+  "tsconfig.json",
+  "turbo.json",
+  "yarn.lock",
+])
+
+export function isReleaseRelevant(relativePath) {
+  const normalized = relativePath.replaceAll("\\", "/")
+  if (rootResolutionFiles.has(normalized)) return true
+  const pkg = packages.find(({ dir }) => normalized.startsWith(`${dir}/`))
+  if (!pkg) return false
+  const local = normalized.slice(pkg.dir.length + 1)
+  if (
+    /(^|\/)(__tests__|test|tests|docs?)\//.test(local) ||
+    /(^|\/)(readme|changelog)(\.[^/]*)?$/i.test(local) ||
+    /\.(test|spec)\.[cm]?[jt]sx?$/.test(local) ||
+    /\.(md|mdx)$/.test(local)
+  ) {
+    return false
+  }
+  return (
+    local === "package.json" ||
+    local === "tsconfig.json" ||
+    local.startsWith("src/") ||
+    local.startsWith("iife/") ||
+    /^(tsup|vite|rollup|webpack)\.config\.[cm]?[jt]s$/.test(local)
+  )
+}
+
+export function directPackagesForFiles(files) {
+  // Root resolution changes can alter every packed dependency graph even when no
+  // package source changed, so conservatively release the entire public surface.
+  if (
+    files.some((file) => rootResolutionFiles.has(file.replaceAll("\\", "/")))
+  ) {
+    return packages.map(({ name }) => name)
+  }
+  return packages
+    .filter(({ dir }) =>
+      files.some(
+        (file) => file.startsWith(`${dir}/`) && isReleaseRelevant(file),
+      ),
+    )
+    .map(({ name }) => name)
+}
+
+export function cascadePackages(direct) {
+  const selected = new Set(direct)
+  const queue = [...direct]
+  while (queue.length) {
+    for (const consumer of consumers[queue.shift()] ?? []) {
+      if (!selected.has(consumer)) {
+        selected.add(consumer)
+        queue.push(consumer)
+      }
+    }
+  }
+  // Config order is topological: dependencies precede their consumers.
+  return packages.map(({ name }) => name).filter((name) => selected.has(name))
+}
+
+export function patchVersion(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version)
+  if (!match) throw new Error(`Expected a stable semver, received ${version}`)
+  return `${match[1]}.${match[2]}.${Number(match[3]) + 1}`
+}
+
+export function compareVersions(left, right) {
+  const parse = (version) => {
+    const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version)
+    if (!match) throw new Error(`Expected a stable semver, received ${version}`)
+    return match.slice(1).map(Number)
+  }
+  const a = parse(left)
+  const b = parse(right)
+  for (let index = 0; index < 3; index += 1) {
+    if (a[index] !== b[index]) return a[index] - b[index]
+  }
+  return 0
+}
+
+export function packageVersion(root, name) {
+  const pkg = packageByName.get(name)
+  if (!pkg) throw new Error(`Package is not on the release allowlist: ${name}`)
+  return JSON.parse(
+    readFileSync(path.join(root, pkg.dir, "package.json"), "utf8"),
+  ).version
+}
+
+export function isReleaseCommit(subject) {
+  return subject.startsWith(RELEASE_MARKER)
+}
+
+export function gitOutput(args, cwd) {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim()
+}
+
+export function changedFiles(root, base, head) {
+  // A branch-creation push has an all-zero base and no meaningful comparison.
+  if (!base || /^0+$/.test(base)) return []
+  const output = gitOutput(["diff", "--name-only", `${base}..${head}`], root)
+  return output ? output.split("\n") : []
+}

--- a/scripts/release/release.mjs
+++ b/scripts/release/release.mjs
@@ -1,0 +1,274 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process"
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import path from "node:path"
+import process from "node:process"
+import { packageByName, packages, RELEASE_MARKER } from "./config.mjs"
+import {
+  cascadePackages,
+  changedFiles,
+  compareVersions,
+  directPackagesForFiles,
+  gitOutput,
+  isReleaseCommit,
+  packageVersion,
+  patchVersion,
+} from "./release-lib.mjs"
+
+const root = path.resolve(import.meta.dirname, "../..")
+const args = Object.fromEntries(
+  process.argv.slice(3).map((value) => {
+    const [key, ...rest] = value.replace(/^--/, "").split("=")
+    return [key, rest.join("=") || true]
+  }),
+)
+const command = process.argv[2] ?? "plan"
+
+const run = (file, fileArgs, options = {}) =>
+  execFileSync(file, fileArgs, { cwd: root, stdio: "inherit", ...options })
+const parseNames = (input) =>
+  String(input ?? "")
+    .split(",")
+    .map((name) => name.trim())
+    .filter(Boolean)
+
+function assertAllowed(names) {
+  for (const name of names) {
+    if (!packageByName.has(name)) throw new Error(`Not publishable: ${name}`)
+  }
+}
+
+async function registryVersion(name) {
+  try {
+    return execFileSync("npm", ["view", name, "version", "--json"], {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+      .trim()
+      .replaceAll('"', "")
+  } catch (error) {
+    const details = `${error.stderr ?? ""}${error.message ?? ""}`
+    if (details.includes("E404")) return null
+    throw error
+  }
+}
+
+const wait = (milliseconds) =>
+  new Promise((resolve) => setTimeout(resolve, milliseconds))
+
+async function registryLatest(name) {
+  try {
+    return execFileSync("npm", ["view", name, "dist-tags.latest", "--json"], {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+      .trim()
+      .replaceAll('"', "")
+  } catch (error) {
+    const details = `${error.stderr ?? ""}${error.message ?? ""}`
+    if (details.includes("E404")) return null
+    throw error
+  }
+}
+
+async function verifyRegistryVersion(name, version) {
+  // npm metadata can lag behind a successful publish. Require both the immutable
+  // version and the mutable `latest` tag before downstream automation may proceed.
+  for (let attempt = 1; attempt <= 6; attempt += 1) {
+    if (
+      (await registryVersion(`${name}@${version}`)) === version &&
+      (await registryLatest(name)) === version
+    ) {
+      return
+    }
+    if (attempt < 6) await wait(2_000)
+  }
+  throw new Error(`Registry verification failed for ${name}@${version}`)
+}
+
+async function plan() {
+  const head = String(args.head || "HEAD")
+  const subject = gitOutput(["show", "-s", "--format=%s", head], root)
+  // The workflow pushes authoritative versions back to main; treating that bot
+  // commit as a no-op prevents an infinite patch-release loop.
+  if (isReleaseCommit(subject))
+    return { direct: [], packages: [], files: [], versions: {} }
+  const files = changedFiles(root, String(args.base || `${head}^`), head)
+  const direct = directPackagesForFiles(files)
+  const selected = cascadePackages(direct)
+  const versions = {}
+  for (const name of selected) {
+    let candidate = patchVersion(packageVersion(root, name))
+    if (args.registry) {
+      // Registry state wins over a stale manifest, and published versions are
+      // skipped because npm versions are immutable.
+      const latest = await registryLatest(name)
+      if (latest && compareVersions(candidate, latest) <= 0) {
+        candidate = patchVersion(latest)
+      }
+      while ((await registryVersion(`${name}@${candidate}`)) === candidate) {
+        candidate = patchVersion(candidate)
+      }
+    }
+    versions[name] = candidate
+  }
+  return { direct, packages: selected, files, versions }
+}
+
+function writePlan(result) {
+  // Committing these versions and the regenerated lockfile makes Git, rather
+  // than ephemeral workflow state, authoritative for recovery operations.
+  for (const name of result.packages) {
+    const { dir } = packageByName.get(name)
+    const manifestPath = path.join(root, dir, "package.json")
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"))
+    manifest.version = result.versions[name]
+    writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+  }
+}
+
+function writeOutput(result) {
+  const json = JSON.stringify(result)
+  console.log(json)
+  if (process.env.GITHUB_OUTPUT) {
+    writeFileSync(
+      process.env.GITHUB_OUTPUT,
+      `plan=${json}\npackages=${result.packages.join(",")}\n`,
+      {
+        flag: "a",
+      },
+    )
+  }
+}
+
+function pack(names) {
+  assertAllowed(names)
+  const out = path.join(root, ".release", "packs")
+  mkdirSync(out, { recursive: true })
+  for (const name of names) {
+    const version = packageVersion(root, name)
+    const filename = `${name.replace("@goodsdks/", "")}-${version}.tgz`
+    run("yarn", ["workspace", name, "pack", "--out", path.join(out, filename)])
+    const listing = execFileSync("tar", ["-tzf", path.join(out, filename)], {
+      encoding: "utf8",
+    })
+    // Validate the actual publication artifact, not only the workspace build.
+    if (
+      !listing.includes("package/package.json") ||
+      !listing.includes("package/dist/")
+    ) {
+      throw new Error(`${filename} is missing package.json or dist output`)
+    }
+  }
+}
+
+function verify(names) {
+  assertAllowed(names)
+  for (const name of names) {
+    run("yarn", ["workspace", name, "build"], {
+      env: { ...process.env, CI: "true" },
+    })
+    const { dir } = packageByName.get(name)
+    const manifest = JSON.parse(
+      readFileSync(path.join(root, dir, "package.json"), "utf8"),
+    )
+    if (manifest.scripts?.lint) {
+      run("yarn", ["workspace", name, "lint"], {
+        env: { ...process.env, CI: "true" },
+      })
+    }
+    if (manifest.scripts?.test) {
+      run("yarn", ["workspace", name, "test"], {
+        env: { ...process.env, CI: "true" },
+      })
+    }
+  }
+}
+
+function tag(names) {
+  assertAllowed(names)
+  for (const name of names) {
+    const version = packageVersion(root, name)
+    const tagName = `${name.replace("@goodsdks/", "")}-v${version}`
+    run("git", ["tag", "-a", tagName, "-m", `${name}@${version}`])
+  }
+}
+
+async function publish(names) {
+  assertAllowed(names)
+  for (const name of names) {
+    const version = packageVersion(root, name)
+    const published = await registryVersion(`${name}@${version}`)
+    if (published === version) {
+      // Recovery is idempotent: repair `latest` when needed instead of attempting
+      // to republish an immutable version.
+      if ((await registryLatest(name)) !== version) {
+        run("npm", ["dist-tag", "add", `${name}@${version}`, "latest"])
+      }
+      await verifyRegistryVersion(name, version)
+      console.log(`${name}@${version} already exists; latest verified`)
+      continue
+    }
+    const filename = path.join(
+      root,
+      ".release",
+      "packs",
+      `${name.replace("@goodsdks/", "")}-${version}.tgz`,
+    )
+    run("npm", ["publish", filename, "--access", "public", "--provenance"])
+    await verifyRegistryVersion(name, version)
+  }
+}
+
+if (command === "plan" || command === "prepare") {
+  const result = await plan()
+  if (command === "prepare" && result.packages.length) writePlan(result)
+  writeOutput(result)
+} else if (command === "pack") {
+  pack(parseNames(args.packages))
+} else if (command === "verify") {
+  verify(parseNames(args.packages))
+} else if (command === "tag") {
+  tag(parseNames(args.packages))
+} else if (command === "assert-bootstrap") {
+  // These pre-existing versions establish registry history before automatic
+  // patching is allowed to begin.
+  const expected = {
+    "@goodsdks/bridging-sdk": "1.0.5",
+    "@goodsdks/engagement-sdk": "1.0.5",
+  }
+  for (const [name, version] of Object.entries(expected)) {
+    if (packageVersion(root, name) !== version) {
+      throw new Error(`Bootstrap requires ${name}@${version} to be committed`)
+    }
+  }
+} else if (command === "check-bootstrap") {
+  // Fail closed on normal pushes until the one-time manual bootstrap has put
+  // both committed versions under npm's `latest` tag.
+  const expected = {
+    "@goodsdks/bridging-sdk": "1.0.5",
+    "@goodsdks/engagement-sdk": "1.0.5",
+  }
+  for (const [name, version] of Object.entries(expected)) {
+    if (
+      (await registryVersion(`${name}@${version}`)) !== version ||
+      (await registryLatest(name)) !== version
+    ) {
+      throw new Error(
+        `${name}@${version} must be bootstrapped under latest with the manual workflow before automatic releases`,
+      )
+    }
+  }
+} else if (command === "publish" || command === "recover") {
+  await publish(parseNames(args.packages))
+} else if (command === "bootstrap") {
+  const names = ["@goodsdks/bridging-sdk", "@goodsdks/engagement-sdk"]
+  pack(names)
+  await publish(names)
+} else {
+  throw new Error(`Unknown release command: ${command}`)
+}
+
+export { RELEASE_MARKER }

--- a/scripts/release/release.test.mjs
+++ b/scripts/release/release.test.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import {
+  cascadePackages,
+  compareVersions,
+  directPackagesForFiles,
+  isReleaseCommit,
+  patchVersion,
+} from "./release-lib.mjs"
+
+test("citizen changes cascade to both published consumers", () => {
+  assert.deepEqual(cascadePackages(["@goodsdks/citizen-sdk"]), [
+    "@goodsdks/citizen-sdk",
+    "@goodsdks/react-hooks",
+    "@goodsdks/ui-components",
+  ])
+})
+
+test("savings SDK changes cascade to the widget", () => {
+  assert.deepEqual(cascadePackages(["@goodsdks/savings-sdk"]), [
+    "@goodsdks/savings-sdk",
+    "@goodsdks/savings-widget",
+  ])
+})
+
+test("engagement remains isolated", () => {
+  assert.deepEqual(cascadePackages(["@goodsdks/engagement-sdk"]), [
+    "@goodsdks/engagement-sdk",
+  ])
+})
+
+test("docs and tests do not trigger releases", () => {
+  assert.deepEqual(
+    directPackagesForFiles([
+      "packages/citizen-sdk/README.md",
+      "packages/citizen-sdk/test/wallet-link.test.ts",
+      "packages/citizen-sdk/src/auth.test.ts",
+    ]),
+    [],
+  )
+})
+
+test("public source, build config and manifest changes trigger releases", () => {
+  assert.deepEqual(
+    directPackagesForFiles([
+      "packages/bridging-sdk/src/index.ts",
+      "packages/invite-sdk/tsup.config.ts",
+      "packages/engagement-sdk/package.json",
+    ]),
+    [
+      "@goodsdks/bridging-sdk",
+      "@goodsdks/engagement-sdk",
+      "@goodsdks/invite-sdk",
+    ],
+  )
+})
+
+test("root resolution changes release the full allowlist", () => {
+  assert.equal(directPackagesForFiles(["yarn.lock"]).length, 10)
+})
+
+test("release marker prevents a release loop", () => {
+  assert.equal(isReleaseCommit("chore(release): publish citizen-sdk [skip release]"), true)
+  assert.equal(isReleaseCommit("fix: citizen"), false)
+})
+
+test("only stable versions receive patch bumps", () => {
+  assert.equal(patchVersion("1.0.5"), "1.0.6")
+  assert.ok(compareVersions("1.0.10", "1.0.9") > 0)
+  assert.throws(() => patchVersion("1.0.5-beta.1"))
+})

--- a/scripts/release/validate-packages.mjs
+++ b/scripts/release/validate-packages.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { packageByName, packages } from "./config.mjs"
+
+const root = path.resolve(import.meta.dirname, "../..")
+// Enforce publication invariants centrally so an accidentally private,
+// source-heavy, or incompletely exported package cannot reach npm.
+for (const expected of packages) {
+  const manifest = JSON.parse(readFileSync(path.join(root, expected.dir, "package.json"), "utf8"))
+  assert.equal(manifest.name, expected.name)
+  assert.notEqual(manifest.private, true, `${manifest.name} must remain public`)
+  // Package metadata must agree with the repository's actual root license.
+  // This prevents npm from advertising terms that contradict the source tree.
+  assert.equal(manifest.license, "MIT", `${manifest.name} needs the MIT license`)
+  assert.equal(manifest.publishConfig?.access, "public", `${manifest.name} needs public access`)
+  assert.equal(
+    manifest.repository?.url,
+    "git+https://github.com/GoodDollar/GoodSDKs.git",
+    `${manifest.name} needs its repository`,
+  )
+  assert.equal(manifest.repository?.directory, expected.dir)
+  assert.deepEqual(manifest.files, ["dist"], `${manifest.name} should ship build output only`)
+  assert.ok(manifest.main, `${manifest.name} needs a main entry`)
+  assert.ok(manifest.module, `${manifest.name} needs an ESM entry`)
+  assert.ok(manifest.types, `${manifest.name} needs a types entry`)
+  assert.ok(manifest.exports, `${manifest.name} needs explicit exports`)
+  assert.doesNotMatch(JSON.stringify(manifest.exports), /index\.cts/, `${manifest.name} has invalid CJS types`)
+  for (const group of ["dependencies", "devDependencies", "peerDependencies"]) {
+    for (const [name, range] of Object.entries(manifest[group] ?? {})) {
+      if (packageByName.has(name) && group !== "peerDependencies") {
+        assert.match(range, /^workspace:\^$/, `${manifest.name} has an unpinned workspace range`)
+      }
+    }
+  }
+}
+console.log(`Validated ${packages.length} publishable package manifests`)

--- a/scripts/scan-build-secrets.mjs
+++ b/scripts/scan-build-secrets.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+import { readFileSync, readdirSync, statSync } from "node:fs"
+import path from "node:path"
+import process from "node:process"
+
+const buildDirectory = path.resolve(process.argv[2] ?? "")
+if (!process.argv[2] || !statSync(buildDirectory).isDirectory()) {
+  throw new Error("Usage: scan-build-secrets.mjs <build-directory>")
+}
+
+const secretName = /(?:^|_)(?:TOKEN|SECRET|PASSWORD|PRIVATE_KEY|AUTH)(?:_|$)/i
+// VITE_* values are intentionally public browser configuration. Everything else
+// matching common CI, npm, Vercel, or secret names must remain absent from output.
+const candidates = Object.entries(process.env).filter(
+  ([name, value]) =>
+    value &&
+    value.length >= 8 &&
+    !name.startsWith("VITE_") &&
+    (secretName.test(name) || /^(?:NPM|VERCEL|CI)_/.test(name)),
+)
+
+function files(directory) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const target = path.join(directory, entry.name)
+    return entry.isDirectory() ? files(target) : [target]
+  })
+}
+
+const leaks = []
+for (const filename of files(buildDirectory)) {
+  const content = readFileSync(filename)
+  for (const [name, value] of candidates) {
+    if (content.includes(Buffer.from(value))) leaks.push(`${name} in ${path.relative(buildDirectory, filename)}`)
+  }
+}
+if (leaks.length) throw new Error(`Secret values found in production assets:\n${leaks.join("\n")}`)
+console.log(`Scanned ${files(buildDirectory).length} production files for ${candidates.length} CI secrets`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2099,7 +2099,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@goodsdks/bridging-sdk@workspace:*, @goodsdks/bridging-sdk@workspace:packages/bridging-sdk":
+"@goodsdks/bridging-sdk@workspace:*, @goodsdks/bridging-sdk@workspace:^, @goodsdks/bridging-sdk@workspace:packages/bridging-sdk":
   version: 0.0.0-use.local
   resolution: "@goodsdks/bridging-sdk@workspace:packages/bridging-sdk"
   dependencies:
@@ -2112,7 +2112,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@goodsdks/citizen-sdk@npm:*, @goodsdks/citizen-sdk@workspace:packages/citizen-sdk":
+"@goodsdks/citizen-sdk@npm:*, @goodsdks/citizen-sdk@workspace:^, @goodsdks/citizen-sdk@workspace:packages/citizen-sdk":
   version: 0.0.0-use.local
   resolution: "@goodsdks/citizen-sdk@workspace:packages/citizen-sdk"
   dependencies:
@@ -2233,7 +2233,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@goodsdks/good-reserve@workspace:*, @goodsdks/good-reserve@workspace:packages/good-reserve":
+"@goodsdks/good-reserve@workspace:*, @goodsdks/good-reserve@workspace:^, @goodsdks/good-reserve@workspace:packages/good-reserve":
   version: 0.0.0-use.local
   resolution: "@goodsdks/good-reserve@workspace:packages/good-reserve"
   dependencies:
@@ -2248,7 +2248,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@goodsdks/invite-sdk@workspace:*, @goodsdks/invite-sdk@workspace:packages/invite-sdk":
+"@goodsdks/invite-sdk@workspace:^, @goodsdks/invite-sdk@workspace:packages/invite-sdk":
   version: 0.0.0-use.local
   resolution: "@goodsdks/invite-sdk@workspace:packages/invite-sdk"
   dependencies:
@@ -2267,11 +2267,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@goodsdks/react-hooks@workspace:packages/react-hooks"
   dependencies:
-    "@goodsdks/bridging-sdk": "workspace:*"
-    "@goodsdks/citizen-sdk": "npm:*"
-    "@goodsdks/good-reserve": "workspace:*"
-    "@goodsdks/invite-sdk": "workspace:*"
-    "@goodsdks/streaming-sdk": "npm:*"
+    "@goodsdks/bridging-sdk": "workspace:^"
+    "@goodsdks/citizen-sdk": "workspace:^"
+    "@goodsdks/good-reserve": "workspace:^"
+    "@goodsdks/invite-sdk": "workspace:^"
+    "@goodsdks/streaming-sdk": "workspace:^"
     "@repo/typescript-config": "workspace:*"
     "@tanstack/react-query": "npm:^4.36.1"
     "@types/react": "npm:^19"
@@ -2287,7 +2287,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@goodsdks/savings-sdk@npm:*, @goodsdks/savings-sdk@workspace:packages/savings-sdk":
+"@goodsdks/savings-sdk@workspace:^, @goodsdks/savings-sdk@workspace:packages/savings-sdk":
   version: 0.0.0-use.local
   resolution: "@goodsdks/savings-sdk@workspace:packages/savings-sdk"
   dependencies:
@@ -2306,7 +2306,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@goodsdks/savings-widget@workspace:packages/savings-widget"
   dependencies:
-    "@goodsdks/savings-sdk": "npm:*"
+    "@goodsdks/savings-sdk": "workspace:^"
     "@repo/typescript-config": "workspace:*"
     lit: "npm:^3.1.0"
     tsup: "npm:^8.3.5"
@@ -2315,7 +2315,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@goodsdks/streaming-sdk@npm:*, @goodsdks/streaming-sdk@workspace:packages/streaming-sdk":
+"@goodsdks/streaming-sdk@npm:*, @goodsdks/streaming-sdk@workspace:^, @goodsdks/streaming-sdk@workspace:packages/streaming-sdk":
   version: 0.0.0-use.local
   resolution: "@goodsdks/streaming-sdk@workspace:packages/streaming-sdk"
   dependencies:
@@ -2338,7 +2338,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@goodsdks/ui-components@workspace:packages/ui-components"
   dependencies:
-    "@goodsdks/citizen-sdk": "npm:*"
+    "@goodsdks/citizen-sdk": "workspace:^"
     "@reown/appkit": "npm:^1.7.2"
     "@reown/appkit-adapter-ethers": "npm:^1.7.2"
     "@repo/typescript-config": "workspace:*"


### PR DESCRIPTION
# Description

This PR adds automated npm release flow for the publishable `@goodsdks/*` packages.

## What changed

- Added `.github/workflows/release-packages.yml`:
  - Runs on `main` pushes (with release-loop guard).
  - Supports manual `workflow_dispatch` modes for `recover` and `bootstrap`.
  - Prepares package versions, updates lockfile, commits release versions, tags, publishes, and verifies npm registry state.
- Added release tooling under `scripts/release/`:
  - `config.mjs`: release allowlist + consumer cascade map.
  - `release-lib.mjs`: changed-file detection, release relevance filters, dependency cascade, semver helpers.
  - `release.mjs`: prepare/verify/pack/tag/publish/bootstrap/check-bootstrap commands.
  - `validate-packages.mjs`: enforces publishable package manifest invariants.
  - `release.test.mjs`: tests package selection, cascade behavior, and release marker handling.
- Added root scripts:
  - `yarn release:plan`
  - `yarn release:test`
  - `yarn release:validate`

## Motivation

Automate safe, repeatable package publishing while keeping release decisions deterministic in git and recoverable after partial registry failures.

## How has this been tested?

- `yarn release:test`
- `yarn release:validate`

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings in targeted validation
- [x] New and existing release tests pass locally
- [x] I have added a detailed description of the changes proposed in the pull request